### PR TITLE
Add "GITHUB_TOKEN" to the list of locations to look for GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is a perfect use case for GitHub’s commit status API.
 
 - `GH_STATUS_TOKEN`
 - `GH_TOKEN`
+- `GITHUB_TOKEN`
 
 That token should have `repo:status` scope.
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const validate = require('./validate')
 exports.post = post
 
 function post ({
-  token = process.env.GH_STATUS_TOKEN || process.env.GH_TOKEN,
+  token = process.env.GH_STATUS_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   sha = process.env.CIRCLE_SHA1 || process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT || process.env.CI_COMMIT_ID,
   owner = process.env.CIRCLE_PROJECT_USERNAME || extractSlug(process.env.TRAVIS_REPO_SLUG, 0) || extractSlug(process.env.CI_REPO_NAME, 0),
   repo = process.env.CIRCLE_PROJECT_REPONAME || extractSlug(process.env.TRAVIS_REPO_SLUG, 1) || extractSlug(process.env.CI_REPO_NAME, 1),


### PR DESCRIPTION
We have `GITHUB_TOKEN` already setup for lots of our builds on CircleCI as it is one of the names supported by https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/ci-configuration.md#authentication - it would be good if this could be added to the fallbacks for commit-status.